### PR TITLE
Control player state with state machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+.DS_Store

--- a/Assets/Scripts/Recording.cs
+++ b/Assets/Scripts/Recording.cs
@@ -1,25 +1,22 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 [RequireComponent(typeof(AudioSource))]
 
 public class Recording : MonoBehaviour
 {
+	public static float AudioReverseSpeed = 3.5f;
 	private AudioSource AudioSource;
-	public float AudioReverseSpeed = 3.5f;
 
 	[System.Serializable]
 	public class Sentiment
 	{
 		public float Timestamp;
 		public string Phrase;
-		public bool Current;
+		public bool Played;
 		public bool Recorded;
 	}
 	public Sentiment[] Sentiments;
 
-    // Start is called before the first frame update
     void Start()
     {
 		AudioSource = GetComponent<AudioSource>(); 
@@ -27,23 +24,20 @@ public class Recording : MonoBehaviour
 
 	public void Play()
 	{
-		if (AudioSource != null)
-		{
-			AudioSource.timeSamples = 0;
-			AudioSource.pitch = 1;
-			AudioSource.Play();
-		}
+		AudioSource.timeSamples = 0;
+		AudioSource.pitch = 1;
+		AudioSource.Play();
 	}
 
 	public void Rewind()
 	{
-		if (AudioSource != null)
-		{
-			// If the audio has reached the end, start at the end
-			if (AudioSource.timeSamples == 0) AudioSource.timeSamples = AudioSource.clip.samples - 1;
-			else AudioSource.timeSamples = AudioSource.timeSamples; // starting position in track - Not sure why this works, possibly an audio buffer reset error?
-			AudioSource.pitch = -AudioReverseSpeed; // pitch changes direction
-			AudioSource.Play();
-		}
+		AudioSource.timeSamples = IsAudioSourcePlaying() ? AudioSource.timeSamples : AudioSource.clip.samples - 1;
+		AudioSource.pitch = -AudioReverseSpeed;
+		AudioSource.Play();
 	}
+
+	public bool IsAudioSourcePlaying()
+    {
+		return AudioSource.isPlaying;
+    }
 }

--- a/Assets/Scripts/Transcript.cs
+++ b/Assets/Scripts/Transcript.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
-using UnityEngine.UI;
 using TMPro;
 
 [RequireComponent(typeof(TMP_Text))]
@@ -11,7 +10,7 @@ public class Transcript : MonoBehaviour
 	public Color CurrentColor = Color.white;
 	public Color RecordedColor = Color.red;
 	private TMP_Text Text;
-
+	
 	public float TextFadeSpeed = 2f;
 
     // Start is called before the first frame update
@@ -22,29 +21,21 @@ public class Transcript : MonoBehaviour
 
     public void SetText(Recording.Sentiment[] sentiments)
 	{
-		string transcript = "";
-		foreach (var sentiment in sentiments)
-		{
-			// Change the color of the sentiment phrase depending on if it is being recorded or has already been played
-			if (sentiment.Recorded)
-			{
-				// Has been heard and recorded, or is recording
-				transcript += "<color=#"+ ColorUtility.ToHtmlStringRGBA(RecordedColor) +">" + sentiment.Phrase + "</color> ";
-			}
-			else if (sentiment.Current)
-			{
-				// Has been heard, but not recorded
-				transcript += "<color=#"+ ColorUtility.ToHtmlStringRGBA(CurrentColor) + ">" + sentiment.Phrase + "</color> ";
-			}
-			else
-			{
-				// Has not yet been heard
-				transcript += sentiment.Phrase + " ";
-			}
-		}
+		string transcript = string.Join(" ", sentiments.Select(sentiment => WrapPhrase(sentiment)));
+		Text.SetText(transcript);
+	}
 
-		// Set the transcript label
-		Text?.SetText(transcript);
+	public string WrapPhrase(Recording.Sentiment sentiment)
+	{
+		if (sentiment.Recorded)
+		{
+			return "<color=#" + ColorUtility.ToHtmlStringRGBA(RecordedColor) + ">" + sentiment.Phrase + "</color>";
+		}
+		else if (sentiment.Played)
+		{
+			return "<color=#" + ColorUtility.ToHtmlStringRGBA(CurrentColor) + ">" + sentiment.Phrase + "</color>";
+		}
+		return sentiment.Phrase;
 	}
 
 	public IEnumerator FadeNonRecordedWords()


### PR DESCRIPTION
Implement a state machine that determines what the player does each game loop, and treat the action buttons as state transitions.

This allows easier implementation of the "Ready", "Done", and "Submitted" states, which fixes a few control bugs. It also adds an explicit "Rewinding" state, which makes certain UI tricks possible, like reverse highlighting.

![Screen Recording 2020-08-02 at 1 07 53 PM](https://user-images.githubusercontent.com/13862873/89128146-86966000-d4c1-11ea-8240-63904c5c1cb8.gif)
